### PR TITLE
Migrate hosting configuration to Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 
 # local documentation files
 *.local.md
+
+# Vercel project metadata
+/.vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ npm test -- --testPathPattern=<filename>
 
 ## Architecture
 
-Pure frontend React 18 SPA (no backend). Bootstrapped with Create React App. Deployed on AWS Amplify (`https://main.d23ipzumjsumtt.amplifyapp.com/#/`) with an alternative gh-pages deploy path.
+Pure frontend React 18 SPA (no backend). Bootstrapped with Create React App. Deployed on Vercel from `main`, with `staging` and pull-request branches deployed as previews.
 
 **Routing** (`App.jsx`): BrowserRouter with four routes — `/`, `/events`, `/faq`, `/about`. `react-helmet-async` is used to inject canonical URLs based on the current path.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "homepage": "https://main.d23ipzumjsumtt.amplifyapp.com/#/",
   "name": "ppreact",
   "version": "0.1.0",
   "private": true,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the Vercel SPA rewrite required by BrowserRouter
- remove the stale Amplify homepage binding
- document Vercel production and preview hosting

## Validation
- production build succeeds
- Vercel preview deployment is ready
- direct requests to /, /events, /about, /faq, and /manifest.json return HTTP 200

Source: AWS Amplify to Vercel hosting migration.